### PR TITLE
fix(legacy-templates): improve the readme note

### DIFF
--- a/src/legacyTemplates.ts
+++ b/src/legacyTemplates.ts
@@ -6,13 +6,13 @@ import { applyTagToNote, getAnyTagWithTitle } from "./utils/tags";
 const README_BODY = (
     `**✅ Legacy Templates successfully imported!**
 
- Quick tips for the Template Plugin:
-  - All notes or to-dos with the \`template\` tag are considered templates, so this import folder can be renamed / reorganized / deleted
-  - To create a new template, create a new note or to-do and add tag \`template\`
+ Quick tips for the Templates Plugin:
+  - All notes or to-dos with the \`template\` tag are considered templates, so this import folder can be renamed / reorganized / deleted.
+  - To create a new template, create a new note or to-do and add tag \`template\`.
   - Your legacy templates are still in your Joplin directory but have been renamed from \`.md\` to \`.md.old\`.
-    - These backups can be deleted once you've confirmed that your templates were correctly imported
+    - These backups can be deleted once you've confirmed that your templates were correctly imported.
   - Templates now support built in variables 🎉 and more. For full documentation and features, see the [README](https://github.com/joplin/plugin-templates#readme).`);
-      
+
 const createTemplatesFolder = async (utils: DateAndTimeUtils): Promise<string> => {
     const folderTitle = `Imported Templates - ${utils.getCurrentTime(utils.getDateFormat())}`;
     return createFolder(folderTitle);

--- a/src/legacyTemplates.ts
+++ b/src/legacyTemplates.ts
@@ -4,16 +4,15 @@ import { createFolder } from "./utils/folders";
 import { applyTagToNote, getAnyTagWithTitle } from "./utils/tags";
 
 const README_BODY = (
-    `**Templates successfully imported!**
+    `**✅ Legacy Templates successfully imported!**
 
-  Here are some quick tips for getting started with the templates plugin:
-  - You can rename this notebook if you want, or shift your templates to any other notebook.
-  - All notes or to-dos with the \`template\` tag are used as templates.
-  - You can delete this readme or notebook if you've shifted your templates to any other notebook.
-  - Your templates are still present in your templates directory but are renamed from \`.md\` to \`.md.old\`.
-    - These backups can be delete once you've confirmed that your templates have been safely imported
-  - For full documentation and features, please refer to the official [readme](https://github.com/joplin/plugin-templates#readme).`);
-
+ Quick tips for the Template Plugin:
+  - All notes or to-dos with the \`template\` tag are considered templates, so this import folder can be renamed / reorganized / deleted
+  - To create a new template, create a new note or to-do and add tag \`template\`
+  - Your legacy templates are still in your Joplin directory but have been renamed from \`.md\` to \`.md.old\`.
+    - These backups can be deleted once you've confirmed that your templates were correctly imported
+  - Templates now support built in variables 🎉 and more. For full documentation and features, see the [README](https://github.com/joplin/plugin-templates#readme).`);
+      
 const createTemplatesFolder = async (utils: DateAndTimeUtils): Promise<string> => {
     const folderTitle = `Imported Templates - ${utils.getCurrentTime(utils.getDateFormat())}`;
     return createFolder(folderTitle);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 1,
     "id": "joplin.plugin.templates",
-    "app_min_version": "2.2.5",
+    "app_min_version": "2.1.5",
     "version": "1.0.0",
     "name": "Templates",
     "description": "This plugin allows you to create and use templates in Joplin.",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 1,
     "id": "joplin.plugin.templates",
-    "app_min_version": "2.1.5",
+    "app_min_version": "2.2.5",
     "version": "1.0.0",
     "name": "Templates",
     "description": "This plugin allows you to create and use templates in Joplin.",


### PR DESCRIPTION
The importing worked really well, just want to make sure it is very clear that the folder itself is not special and notes / to-dos need a `template` tag. Thanks for building this plugin, it is great!