### PR TITLE
fix: bugs in copyFolderID command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,13 +161,13 @@ joplin.plugins.register({
             name: "copyFolderID",
             label: "Copy notebook ID",
             execute: async (folderId: string) => {
-                if (typeof folderId === 'undefined') {
+                if (typeof folderId === "undefined") {
                     const selectedFolder = await joplin.workspace.selectedFolder();
                     folderId = selectedFolder.id;
                 }
                 navigator.clipboard.writeText(folderId);
 
-                await joplin.commands.execute('editor.focus');
+                await joplin.commands.execute("editor.focus");
             }
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,13 @@ joplin.plugins.register({
             name: "copyFolderID",
             label: "Copy notebook ID",
             execute: async (folderId: string) => {
-                await joplin.clipboard.writeText(folderId);
+                if (typeof folderId === 'undefined') {
+                    const selectedFolder = await joplin.workspace.selectedFolder();
+                    folderId = selectedFolder.id;
+                }
+                navigator.clipboard.writeText(folderId);
+
+                await joplin.commands.execute('editor.focus');
             }
         });
 


### PR DESCRIPTION
The current implementation to retrieve the notebook id has 2 issues:

- when using the command palette, the returned id will be `undefined`
- the editor loses focus and one has to click the editor again

This PR fixes both of these issues.

