### PR TITLE
fix(#49): id not copied in newer versions of electron 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ joplin.plugins.register({
                     const selectedFolder = await joplin.workspace.selectedFolder();
                     folderId = selectedFolder.id;
                 }
-                navigator.clipboard.writeText(folderId);
+                await joplin.clipboard.writeText(folderId);
 
                 await joplin.commands.execute("editor.focus");
             }


### PR DESCRIPTION
fixes #49 

Apparently newer versions of Electron do not understand `navigator.clipboard.writeText()` anymore.