### PR TITLE
Add additional custom handlers for upper and lower case custom dates

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,12 @@ export class Parser {
         Handlebars.registerHelper("custom_datetime", (options) => {
             return this.utils.getCurrentTime(options.fn(this));
         });
+        Handlebars.registerHelper("upper_datetime", (options) => {
+            return this.utils.getCurrentTime(options.fn(this)).toUpperCase();
+        });
+        Handlebars.registerHelper("lower_datetime", (options) => {
+            return this.utils.getCurrentTime(options.fn(this)).toLowerCase();
+        });
 
         return {
             date: this.utils.getCurrentTime(this.utils.getDateFormat()),


### PR DESCRIPTION
I prefer to have custom dates displayed in all caps, however custom_date does not support this natively. These two alternate handlers provide upper and lower conversion to custom dates.