### PR TITLE
Allow logical comparisons in handlebars

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -284,24 +284,42 @@ export class Parser {
         Handlebars.registerHelper("compare", function (v1, operator, v2, options) {
             switch (operator) {
                 case "==":
+                case "eq":
+                case "equals":
                     return (v1 == v2) ? options.fn(this) : options.inverse(this);
                 case "===":
+                case "seq":
+                case "strictly-equals":
                     return (v1 === v2) ? options.fn(this) : options.inverse(this);
                 case "!=":
+                case "ne":
+                case "not-equals":
                     return (v1 != v2) ? options.fn(this) : options.inverse(this);
                 case "!==":
+                case "sne":
+                case "strictly-not-equals":
                     return (v1 !== v2) ? options.fn(this) : options.inverse(this);
                 case "<":
+                case "lt":
+                case "less-than":
                     return (v1 < v2) ? options.fn(this) : options.inverse(this);
                 case "<=":
+                case "lte":
+                case "less-than-equals":
                     return (v1 <= v2) ? options.fn(this) : options.inverse(this);
                 case ">":
+                case "gt":
+                case "greater-than":
                     return (v1 > v2) ? options.fn(this) : options.inverse(this);
                 case ">=":
+                case "gte":
+                case "greater-than-equals":
                     return (v1 >= v2) ? options.fn(this) : options.inverse(this);
                 case "&&":
+                case "and":
                     return (v1 && v2) ? options.fn(this) : options.inverse(this);
                 case "||":
+                case "or":
                     return (v1 || v2) ? options.fn(this) : options.inverse(this);
                 default:
                     return options.inverse(this);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,9 +38,7 @@ export class Parser {
     }
 
     private getDefaultContext() {
-        Handlebars.registerHelper("custom_datetime", (options) => {
-            return this.utils.getCurrentTime(options.fn(this));
-        });
+        this.registerHelpers()
 
         return {
             date: this.utils.getCurrentTime(this.utils.getDateFormat()),
@@ -276,5 +274,11 @@ export class Parser {
             await joplin.views.dialogs.showMessageBox(`There was an error parsing this template, please review it and try again.\n\n${err}`);
             return null;
         }
+    }
+
+    private registerHelpers() {
+        Handlebars.registerHelper("custom_datetime", (options) => {
+            return this.utils.getCurrentTime(options.fn(this));
+        });
     }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -280,5 +280,32 @@ export class Parser {
         Handlebars.registerHelper("custom_datetime", (options) => {
             return this.utils.getCurrentTime(options.fn(this));
         });
+
+        Handlebars.registerHelper("compare", function (v1, operator, v2, options) {
+            switch (operator) {
+                case "==":
+                    return (v1 == v2) ? options.fn(this) : options.inverse(this);
+                case "===":
+                    return (v1 === v2) ? options.fn(this) : options.inverse(this);
+                case "!=":
+                    return (v1 != v2) ? options.fn(this) : options.inverse(this);
+                case "!==":
+                    return (v1 !== v2) ? options.fn(this) : options.inverse(this);
+                case "<":
+                    return (v1 < v2) ? options.fn(this) : options.inverse(this);
+                case "<=":
+                    return (v1 <= v2) ? options.fn(this) : options.inverse(this);
+                case ">":
+                    return (v1 > v2) ? options.fn(this) : options.inverse(this);
+                case ">=":
+                    return (v1 >= v2) ? options.fn(this) : options.inverse(this);
+                case "&&":
+                    return (v1 && v2) ? options.fn(this) : options.inverse(this);
+                case "||":
+                    return (v1 || v2) ? options.fn(this) : options.inverse(this);
+                default:
+                    return options.inverse(this);
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes: #56, #64

Adds the compare helper and various useful comparisons

Example use case:
```
---
topics:
  label: How many topic headers to use?
  type: num

---

{{#compare topics ">=" 1}}
# Header 1

{{#compare topics ">=" 2}}
# Header 2

{{#compare topics ">=" 3}}
# Header 3

{{/compare}}
{{/compare}}
{{/compare}}
```

Not included, but is a good idea:
- This should be mentioned in the README somewhere
- Needs tests added (I had a quick look but I'm not familiar with testing in JS/TS)