### PR TITLE
feat: add automatically incremented note id feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,14 @@ These are the variables that have a specific purpose other than being used in te
 - Both built-in and custom variables can be used while defining these variables.
 - The values of these variables can be used in the template body just like built-in and custom variables.
 
-Currently there are two special variables.
+Currently there are four special variables.
 
 | Variable | Purpose | Example |
 | --- | --- | --- |
 | `template_title` | Title of the note/to-do created using this template. | template_title: Standup - {{ date }} |
 | `template_tags` | Comma separated tags to be applied to the note/to-do created  using this template. | template_tags: spec, {{ project }} |
 | `template_notebook` | The ID of the target notebook for this template. Whenever a new note/to-do will be created by this template, it will be created in this target notebook. | template_notebook: 82d2384b025f44588e4d3851a1237028 |
+| ˙template_auto_incremented_prefix` | Adds an automatically incremented ID with "prefix string-incremented id: " format to the the title as a prefix. | template_auto_incremented_prefix: "prefix string" |
 
 **Points to note**
 - If `template_title` is not provided, the title of the template will be used as a fallback value.

--- a/tests/mock-joplin-api.ts
+++ b/tests/mock-joplin-api.ts
@@ -1,7 +1,13 @@
+import { Path } from "api/types";
+
 export default {
     commands: {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         execute: async (cmd: string, props: unknown): Promise<unknown> => { return ""; }
+    },
+    data: {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        get: async (path: Path, query?: unknown): Promise<unknown> => { return { items: [], has_more: false }; }
     },
     views: {
         dialogs: {

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -341,6 +341,50 @@ describe("Template parser", () => {
         `);
     });
 
+    test("should parse auto incremented prefix special variables correctly", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        jest.spyOn(joplin.data, "get").mockImplementation(async (path, query) => {
+            console.log("GET CALLED");
+            return { items: [], has_more: false };
+        });
+        const parsedTemplate = await parser.parseTemplate({
+            id: "note-id",
+            title: "Some template",
+            body: dedent`
+                ---
+                template_auto_incremented_prefix: "TEST"
+
+                ---
+            `
+        });
+        expect(parsedTemplate.title).toEqual("TEST-1: Some template");
+    });
+
+    test("should parse auto incremented prefix special variables and increment title correctly", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        jest.spyOn(joplin.data, "get").mockImplementation(async (path, query) => {
+            console.log("GET CALLED");
+            return {
+                items: [{
+                    id: "notebook id",
+                    title: "TEST-100: Some template",
+                }],
+                has_more: false
+            };
+        });
+        const parsedTemplate = await parser.parseTemplate({
+            id: "note-id",
+            title: "Some template",
+            body: dedent`
+                ---
+                template_auto_incremented_prefix: "TEST"
+
+                ---
+            `
+        });
+        expect(parsedTemplate.title).toEqual("TEST-101: Some template");
+    });
+
     test("should show an error message if value of a special variable is not a string", async () => {
         const template = {
             id: "note-id",


### PR DESCRIPTION
I use Joplin to manage tasks in some of my projects. I reference these tasks within Joplin by copying the markdown link or using the node id. However, it is challenging to uniquely identify tasks outside of Joplin, such as in commit messages.

To address this issue, I propose introducing a new special variable called template_auto_incremented_prefix. This variable will add a note id prefix in the format of "prefix string-incremented id: " (e.g., "TEST-1: Initial commit" and "TEST-2: First feature").

Any comments or improvement ideas are welcome.