### PR TITLE
fix(datetime-helper): consider seconds in set_time helper

### DIFF
--- a/src/helpers/datetime.ts
+++ b/src/helpers/datetime.ts
@@ -78,7 +78,7 @@ export const datetimeHelper: HelperConstructorBlock = (ctx) => {
             const parsedTime = ctx.dateAndTimeUtils.parseTime(attrs[SET_TIME] as string, ctx.dateAndTimeUtils.getTimeFormat());
             now.set("hours", parsedTime.hours);
             now.set("minutes", parsedTime.minutes);
-            now.set("seconds", 0);
+            now.set("seconds", parsedTime.seconds);
             now.set("milliseconds", 0);
         }
 

--- a/src/utils/dateAndTime.ts
+++ b/src/utils/dateAndTime.ts
@@ -12,6 +12,7 @@ interface ParsedDate {
 interface ParsedTime {
     hours: number;
     minutes: number;
+    seconds: number;
 }
 
 export class DateAndTimeUtils {
@@ -82,6 +83,7 @@ export class DateAndTimeUtils {
         return {
             hours: time.hours(),
             minutes: time.minutes(),
+            seconds: time.seconds(),
         };
     }
 }


### PR DESCRIPTION
Note - I don't actually recall why I set seconds as `0` when originally developing this feature. Will revert this pr if something breaks. 