### PR TITLE
feat(dev): refactor settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,8 @@ module.exports = {
     moduleFileExtensions: ["ts", "js", "json", "node"],
     moduleNameMapper: {
         "^@templates/(.*)$": "<rootDir>/src/$1",
-        "^api$": "<rootDir>/tests/mock-joplin-api.ts"
+        "^api$": "<rootDir>/tests/mock-joplin-api.ts",
+        "^api/types$": "<rootDir>/api/types.ts"
     },
     globalSetup: "./tests/jest-setup.js",
     collectCoverageFrom: ["src/**/*.{js,ts}"]

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,6 +2,7 @@ import joplin from "api";
 import { NewNote } from "./parser";
 import { getSelectedFolder } from "./utils/folders";
 import { applyTagToNote, getAnyTagWithTitle } from "./utils/tags";
+import { ApplyTagsWhileInsertingSetting } from "./settings";
 
 export enum TemplateAction {
     NewNote = "newNote",
@@ -12,7 +13,7 @@ export enum TemplateAction {
 const performInsertTextAction = async (template: NewNote) => {
     await joplin.commands.execute("insertText", template.body);
 
-    const applyTags = await joplin.settings.value("applyTagsWhileInserting")
+    const applyTags = await ApplyTagsWhileInsertingSetting.get()
     if (applyTags) {
         const noteId = (await joplin.workspace.selectedNote()).id;
         for (const tag of template.tags) {

--- a/src/settings/applyTagsWhileInserting.ts
+++ b/src/settings/applyTagsWhileInserting.ts
@@ -1,0 +1,11 @@
+import { SettingItemType } from "api/types";
+import { createSimpleSetting } from "./base";
+
+export const ApplyTagsWhileInsertingSetting = createSimpleSetting<boolean>("applyTagsWhileInserting", {
+    public: true,
+    type: SettingItemType.Bool,
+    value: true,
+    label: "Apply tags while inserting template",
+    description: "Apply tags using 'template_tags' variable while inserting template to notes/to-dos.",
+    section: "templatesPlugin"
+});

--- a/src/settings/base.ts
+++ b/src/settings/base.ts
@@ -25,10 +25,10 @@ export const createSimpleSetting = <T>(id: string, manifest: SettingItem): Plugi
 }
 
 /**
- * This considers that the original setting is of type string. On `set` if no original value
- * can be calculated, the setting is set to an empty string.
+ * This considers that the original setting is of type `string`. On `set` if no original value
+ * can be traced back, the setting is set to an empty string.
  */
-export const createEnumSetting = <T>(id: string, manifest: SettingItem, valueMap: Record<string, T>, defaultValue: T): PluginSetting<T> => {
+export const createMappedSetting = <T>(id: string, manifest: SettingItem, valueMap: Record<string, T>, defaultValue: T): PluginSetting<T> => {
     return class {
         static id = id;
         static manifest = manifest;

--- a/src/settings/base.ts
+++ b/src/settings/base.ts
@@ -1,0 +1,25 @@
+import joplin from "api";
+import { SettingItem } from "api/types";
+
+export interface PluginSetting<T> {
+    id: string;
+    manifest: SettingItem;
+
+    get(): Promise<T>;
+    set(newValue: T): Promise<void>;
+}
+
+export const createSimpleSetting = <T>(id: string, manifest: SettingItem): PluginSetting<T> => {
+    return class {
+        static id = id;
+        static manifest = manifest;
+
+        static async get(): Promise<T> {
+            return await joplin.settings.value(id);
+        }
+
+        static async set(newValue: T): Promise<void> {
+            await joplin.settings.setValue(id, newValue);
+        }
+    }
+}

--- a/src/settings/base.ts
+++ b/src/settings/base.ts
@@ -40,7 +40,7 @@ export const createMappedSetting = <T>(id: string, manifest: SettingItem, valueM
 
         static async set(newValue: T): Promise<void> {
             const potentialValues = Object.entries(valueMap).filter((entry) => entry[1] === newValue);
-            await joplin.settings.setValue(id, potentialValues.length ? potentialValues[1][0] : "" );
+            await joplin.settings.setValue(id, potentialValues.length ? potentialValues[0][0] : "" );
         }
     }
 }

--- a/src/settings/base.ts
+++ b/src/settings/base.ts
@@ -23,3 +23,24 @@ export const createSimpleSetting = <T>(id: string, manifest: SettingItem): Plugi
         }
     }
 }
+
+/**
+ * This considers that the original setting is of type string. On `set` if no original value
+ * can be calculated, the setting is set to an empty string.
+ */
+export const createEnumSetting = <T>(id: string, manifest: SettingItem, valueMap: Record<string, T>, defaultValue: T): PluginSetting<T> => {
+    return class {
+        static id = id;
+        static manifest = manifest;
+
+        static async get(): Promise<T> {
+            const value: string = await joplin.settings.value(id);
+            return value in valueMap ? valueMap[value] : defaultValue;
+        }
+
+        static async set(newValue: T): Promise<void> {
+            const potentialValues = Object.entries(valueMap).filter((entry) => entry[1] === newValue);
+            await joplin.settings.setValue(id, potentialValues.length ? potentialValues[1][0] : "" );
+        }
+    }
+}

--- a/src/settings/defaultNoteTemplateId.ts
+++ b/src/settings/defaultNoteTemplateId.ts
@@ -1,0 +1,9 @@
+import { SettingItemType } from "api/types";
+import { createSimpleSetting } from "./base";
+
+export const DefaultNoteTemplateIdSetting = createSimpleSetting<string | null>("defaultNoteTemplateId", {
+    public: false,
+    type: SettingItemType.String,
+    value: null,
+    label: "Default note template ID"
+});

--- a/src/settings/defaultTemplatesConfig.ts
+++ b/src/settings/defaultTemplatesConfig.ts
@@ -1,0 +1,30 @@
+import joplin from "api";
+import { SettingItemType } from "api/types";
+import { PluginSetting } from "./base";
+
+export interface DefaultTemplatesConfig {
+    [notebookId: string]: {
+        defaultNoteTemplateId: string | null;
+        defaultTodoTemplateId: string | null;
+    }
+}
+
+export const DefaultTemplatesConfigSetting: PluginSetting<DefaultTemplatesConfig> = class {
+    static id = "defaultTemplatesConfig";
+
+    static manifest = {
+        public: false,
+        type: SettingItemType.Object,
+        value: null,
+        label: "Default templates config"
+    };
+
+    static async get(): Promise<DefaultTemplatesConfig> {
+        const defaultTemplatesConfig: DefaultTemplatesConfig | null = await joplin.settings.value(DefaultTemplatesConfigSetting.id);
+        return defaultTemplatesConfig ? defaultTemplatesConfig : {};
+    }
+
+    static async set(newValue: DefaultTemplatesConfig): Promise<void> {
+        await joplin.settings.setValue(DefaultTemplatesConfigSetting.id, newValue);
+    }
+}

--- a/src/settings/defaultTemplatesConfig.ts
+++ b/src/settings/defaultTemplatesConfig.ts
@@ -1,6 +1,5 @@
 import joplin from "api";
 import { SettingItemType } from "api/types";
-import { PluginSetting } from "./base";
 
 export interface DefaultTemplatesConfig {
     [notebookId: string]: {
@@ -9,7 +8,15 @@ export interface DefaultTemplatesConfig {
     }
 }
 
-export const DefaultTemplatesConfigSetting: PluginSetting<DefaultTemplatesConfig> = class {
+enum DefaultType {
+    Both,
+    Note,
+    Todo,
+}
+
+export const DefaultTemplatesConfigSetting = class {
+    static readonly DefaultType = DefaultType;
+
     static id = "defaultTemplatesConfig";
 
     static manifest = {
@@ -26,5 +33,39 @@ export const DefaultTemplatesConfigSetting: PluginSetting<DefaultTemplatesConfig
 
     static async set(newValue: DefaultTemplatesConfig): Promise<void> {
         await joplin.settings.setValue(DefaultTemplatesConfigSetting.id, newValue);
+    }
+
+    static async setDefaultTempalte(notebookId: string, templateId: string, defaultType: DefaultType): Promise<void> {
+        const defaultTemplatesConfig = await this.get();
+
+        if (!(notebookId in defaultTemplatesConfig)) {
+            defaultTemplatesConfig[notebookId] = {
+                defaultNoteTemplateId: null,
+                defaultTodoTemplateId: null
+            };
+        }
+
+        switch (defaultType) {
+            case DefaultType.Note:
+                defaultTemplatesConfig[notebookId].defaultNoteTemplateId = templateId;
+                break;
+            case DefaultType.Todo:
+                defaultTemplatesConfig[notebookId].defaultTodoTemplateId = templateId;
+                break;
+            case DefaultType.Both:
+                defaultTemplatesConfig[notebookId].defaultNoteTemplateId = templateId;
+                defaultTemplatesConfig[notebookId].defaultTodoTemplateId = templateId;
+                break;
+            default:
+                break;
+        }
+
+        await this.set(defaultTemplatesConfig);
+    }
+
+    static async clearDefaultTemplates(notebookId: string): Promise<void> {
+        const defaultTemplatesConfig = await this.get();
+        delete defaultTemplatesConfig[notebookId];
+        await this.set(defaultTemplatesConfig);
     }
 }

--- a/src/settings/defaultTodoTemplateId.ts
+++ b/src/settings/defaultTodoTemplateId.ts
@@ -1,0 +1,9 @@
+import { SettingItemType } from "api/types";
+import { createSimpleSetting } from "./base";
+
+export const DefaultTodoTemplateIdSetting = createSimpleSetting<string | null>("defaultTodoTemplateId", {
+    public: false,
+    type: SettingItemType.String,
+    value: null,
+    label: "Default to-do template ID"
+});

--- a/src/settings/global/base.ts
+++ b/src/settings/global/base.ts
@@ -1,0 +1,16 @@
+import joplin from "api";
+
+export interface GlobalSetting<T> {
+    id: string;
+    get(): Promise<T>;
+}
+
+export const createGlobalSetting = <T>(id: string): GlobalSetting<T> => {
+    return class {
+        static id = id;
+
+        static async get(): Promise<T> {
+            return await joplin.settings.globalValue(id);
+        }
+    }
+}

--- a/src/settings/global/index.ts
+++ b/src/settings/global/index.ts
@@ -1,0 +1,9 @@
+import { createGlobalSetting } from "./base";
+
+export const LocaleGlobalSetting = createGlobalSetting<string>("locale");
+
+export const DateFormatGlobalSetting = createGlobalSetting<string>("dateFormat");
+
+export const TimeFormatGlobalSetting = createGlobalSetting<string>("timeFormat");
+
+export const ProfileDirGlobalSetting = createGlobalSetting<string>("profileDir");

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,0 +1,9 @@
+// Export all individual settings
+export { ApplyTagsWhileInsertingSetting } from "./applyTagsWhileInserting";
+export { DefaultNoteTemplateIdSetting } from "./defaultNoteTemplateId";
+export { DefaultTemplatesConfigSetting } from "./defaultTemplatesConfig";
+export { DefaultTodoTemplateIdSetting } from "./defaultTodoTemplateId";
+export { TemplatesSourceSetting } from "./templatesSource";
+
+// Export registry
+export { PluginSettingsRegistry } from "./registry";

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -1,0 +1,34 @@
+import joplin from "api";
+import { SettingItem } from "api/types";
+
+import { ApplyTagsWhileInsertingSetting } from "./applyTagsWhileInserting";
+import { DefaultNoteTemplateIdSetting } from "./defaultNoteTemplateId";
+import { DefaultTemplatesConfigSetting } from "./defaultTemplatesConfig";
+import { DefaultTodoTemplateIdSetting } from "./defaultTodoTemplateId";
+import { TemplatesSourceSetting } from "./templatesSource";
+
+import { PluginSetting } from "./base";
+
+export class PluginSettingsRegistry {
+    private static allPluginSettings: PluginSetting<unknown>[] = [
+        ApplyTagsWhileInsertingSetting,
+        DefaultNoteTemplateIdSetting,
+        DefaultTemplatesConfigSetting,
+        DefaultTodoTemplateIdSetting,
+        TemplatesSourceSetting,
+    ];
+
+    public static async registerSettings(): Promise<void> {
+        // Register setting section
+        await joplin.settings.registerSection("templatesPlugin", {
+            label: "Templates",
+        });
+
+        // Register all settings
+        const settingsManifest: Record<string, SettingItem> = this.allPluginSettings.reduce((manifest, setting) => {
+            manifest[setting.id] = setting.manifest;
+            return manifest;
+        }, {});
+        await joplin.settings.registerSettings(settingsManifest);
+    }
+}

--- a/src/settings/templatesSource.ts
+++ b/src/settings/templatesSource.ts
@@ -6,13 +6,6 @@ export enum TemplatesSource {
     Notebook,
 }
 
-const createValueMap = (): Record<string, TemplatesSource> => {
-    const valueMap: Record<string, TemplatesSource> = {};
-    valueMap["tag"] = TemplatesSource.Tag;
-    valueMap["notebook"] = TemplatesSource.Notebook;
-    return valueMap;
-}
-
 export const TemplatesSourceSetting = createEnumSetting<TemplatesSource>("templatesSource", {
     public: true,
     type: SettingItemType.String,
@@ -25,4 +18,4 @@ export const TemplatesSourceSetting = createEnumSetting<TemplatesSource>("templa
     label: "Are templates set with tags or stored in a notebook?",
     description: "If set to 'Tag', any note/to-do with a 'template' tag is considered a template. If set to 'Notebook', any note/todo stored in a notebook titled 'Templates' is considered a template.",
     section: "templatesPlugin"
-}, createValueMap(), TemplatesSource.Tag);
+}, { "tag": TemplatesSource.Tag, "notebook": TemplatesSource.Notebook }, TemplatesSource.Tag);

--- a/src/settings/templatesSource.ts
+++ b/src/settings/templatesSource.ts
@@ -1,7 +1,19 @@
 import { SettingItemType } from "api/types";
-import { createSimpleSetting } from "./base";
+import { createEnumSetting } from "./base";
 
-export const TemplatesSourceSetting = createSimpleSetting<string>("templatesSource", {
+export enum TemplatesSource {
+    Tag,
+    Notebook,
+}
+
+const createValueMap = (): Record<string, TemplatesSource> => {
+    const valueMap: Record<string, TemplatesSource> = {};
+    valueMap["tag"] = TemplatesSource.Tag;
+    valueMap["notebook"] = TemplatesSource.Notebook;
+    return valueMap;
+}
+
+export const TemplatesSourceSetting = createEnumSetting<TemplatesSource>("templatesSource", {
     public: true,
     type: SettingItemType.String,
     isEnum: true,
@@ -13,4 +25,4 @@ export const TemplatesSourceSetting = createSimpleSetting<string>("templatesSour
     label: "Are templates set with tags or stored in a notebook?",
     description: "If set to 'Tag', any note/to-do with a 'template' tag is considered a template. If set to 'Notebook', any note/todo stored in a notebook titled 'Templates' is considered a template.",
     section: "templatesPlugin"
-});
+}, createValueMap(), TemplatesSource.Tag);

--- a/src/settings/templatesSource.ts
+++ b/src/settings/templatesSource.ts
@@ -1,0 +1,16 @@
+import { SettingItemType } from "api/types";
+import { createSimpleSetting } from "./base";
+
+export const TemplatesSourceSetting = createSimpleSetting<string>("templatesSource", {
+    public: true,
+    type: SettingItemType.String,
+    isEnum: true,
+    value: "tag",
+    options: {
+        "tag": "Tag",
+        "notebook": "Notebook"
+    },
+    label: "Are templates set with tags or stored in a notebook?",
+    description: "If set to 'Tag', any note/to-do with a 'template' tag is considered a template. If set to 'Notebook', any note/todo stored in a notebook titled 'Templates' is considered a template.",
+    section: "templatesPlugin"
+});

--- a/src/settings/templatesSource.ts
+++ b/src/settings/templatesSource.ts
@@ -1,12 +1,12 @@
 import { SettingItemType } from "api/types";
-import { createEnumSetting } from "./base";
+import { createMappedSetting } from "./base";
 
 export enum TemplatesSource {
     Tag,
     Notebook,
 }
 
-export const TemplatesSourceSetting = createEnumSetting<TemplatesSource>("templatesSource", {
+export const TemplatesSourceSetting = createMappedSetting<TemplatesSource>("templatesSource", {
     public: true,
     type: SettingItemType.String,
     isEnum: true,

--- a/src/utils/defaultTemplates.ts
+++ b/src/utils/defaultTemplates.ts
@@ -1,11 +1,5 @@
 import joplin from "api";
-
-export interface DefaultTemplatesConfigSetting {
-    [notebookId: string]: {
-        defaultNoteTemplateId: string | null;
-        defaultTodoTemplateId: string | null;
-    }
-}
+import { DefaultTemplatesConfigSetting, DefaultNoteTemplateIdSetting, DefaultTodoTemplateIdSetting } from "../settings";
 
 export enum DefaultTemplateType {
     Both,
@@ -45,57 +39,30 @@ export const setDefaultTemplate = async (notebookId: string | null, templateId: 
         // Global default
         switch (defaultType) {
             case DefaultTemplateType.Note:
-                await joplin.settings.setValue("defaultNoteTemplateId", templateId);
+                await DefaultNoteTemplateIdSetting.set(templateId);
                 break;
             case DefaultTemplateType.Todo:
-                await joplin.settings.setValue("defaultTodoTemplateId", templateId);
+                await DefaultTodoTemplateIdSetting.set(templateId);
                 break;
             case DefaultTemplateType.Both:
-                await joplin.settings.setValue("defaultNoteTemplateId", templateId);
-                await joplin.settings.setValue("defaultTodoTemplateId", templateId);
+                await DefaultNoteTemplateIdSetting.set(templateId);
+                await DefaultTodoTemplateIdSetting.set(templateId);
                 break;
             default:
                 break;
         }
     } else {
         // Notebook specific default
-        let defaultTemplatesConfig: DefaultTemplatesConfigSetting | null = await joplin.settings.value("defaultTemplatesConfig");
-        if (defaultTemplatesConfig === null) defaultTemplatesConfig = {};
-
-        if (!(notebookId in defaultTemplatesConfig)) {
-            defaultTemplatesConfig[notebookId] = {
-                defaultNoteTemplateId: null,
-                defaultTodoTemplateId: null
-            };
-        }
-
         switch (defaultType) {
             case DefaultTemplateType.Note:
-                defaultTemplatesConfig[notebookId].defaultNoteTemplateId = templateId;
+                await DefaultTemplatesConfigSetting.setDefaultTempalte(notebookId, templateId, DefaultTemplatesConfigSetting.DefaultType.Note);
                 break;
             case DefaultTemplateType.Todo:
-                defaultTemplatesConfig[notebookId].defaultTodoTemplateId = templateId;
+                await DefaultTemplatesConfigSetting.setDefaultTempalte(notebookId, templateId, DefaultTemplatesConfigSetting.DefaultType.Todo);
                 break;
             case DefaultTemplateType.Both:
-                defaultTemplatesConfig[notebookId].defaultNoteTemplateId = templateId;
-                defaultTemplatesConfig[notebookId].defaultTodoTemplateId = templateId;
-                break;
-            default:
+                await DefaultTemplatesConfigSetting.setDefaultTempalte(notebookId, templateId, DefaultTemplatesConfigSetting.DefaultType.Both);
                 break;
         }
-
-        await joplin.settings.setValue("defaultTemplatesConfig", defaultTemplatesConfig);
     }
-}
-
-export const getNotebookDefaultTemplatesConfig = async (): Promise<DefaultTemplatesConfigSetting> => {
-    let defaultTemplatesConfig: DefaultTemplatesConfigSetting | null = await joplin.settings.value("defaultTemplatesConfig");
-    if (defaultTemplatesConfig === null) defaultTemplatesConfig = {};
-    return defaultTemplatesConfig;
-}
-
-export const clearDefaultTemplates = async (notebookId: string): Promise<void> => {
-    const defaultTemplatesConfig = await getNotebookDefaultTemplatesConfig();
-    delete defaultTemplatesConfig[notebookId];
-    await joplin.settings.setValue("defaultTemplatesConfig", defaultTemplatesConfig);
 }

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,6 +1,8 @@
 import joplin from "api";
 import { getAllNotesInFolder } from "./folders";
 import { getAllNotesWithTag, getAllTagsWithTitle } from "./tags";
+import { TemplatesSourceSetting, TemplatesSource } from "../settings/templatesSource";
+import { LocaleGlobalSetting } from "../settings/global";
 
 export interface Note {
     id: string;
@@ -27,9 +29,9 @@ const removeDuplicateTemplates = (templates: Note[]) => {
 const getAllTemplates = async () => {
     let templates: Note[] = [];
 
-    const templatesSource = await joplin.settings.value("templatesSource");
+    const templatesSource = await TemplatesSourceSetting.get();
 
-    if (templatesSource == "tag"){
+    if (templatesSource == TemplatesSource.Tag) {
         const templateTags = await getAllTagsWithTitle("template");
 
         for (const tag of templateTags) {
@@ -41,7 +43,7 @@ const getAllTemplates = async () => {
 
     templates = removeDuplicateTemplates(templates);
 
-    let userLocale: string = await joplin.settings.globalValue("locale");
+    let userLocale: string = await LocaleGlobalSetting.get();
     userLocale = userLocale.split("_").join("-");
 
     templates.sort((a, b) => {


### PR DESCRIPTION
- [x] "index.ts" to export all settings and register all settings.
- [x] a joplin read-only settings accessor
- [x] some code from "./utils/defaultTemplates" & "index.ts" can be moved to the settings accessor
- [x] use these settings everywhere