### PR TITLE
fix: use parsed number instead of raw string in repeat helper loop

### DIFF
--- a/src/helpers/repeat.ts
+++ b/src/helpers/repeat.ts
@@ -9,8 +9,8 @@ export const repeatHelper: HelperConstructorBlock = (ctx) => {
         }
 
         let ret = "";
-        for (let i = 0; i < rawNum; i++) {
-            ret += options.fn({ ...this, "repeat_index": i });
+        for (let i = 0; i < num; i++) {
+            ret += options.fn({ ...this, repeat_index: i });
         }
         return ret;
     });


### PR DESCRIPTION
### What

Fixes a bug in the `repeat` Handlebars helper where the loop condition used the unparsed string argument (`rawNum`) instead of the `parseInt`-parsed integer (`num`).

### Why

Although JavaScript's implicit type coercion made the comparison `i < rawNum` work for typical inputs, using the raw string is semantically incorrect. The `parseInt` call exists specifically to validate and convert the input — the parsed result `num` should be used consistently after validation.

### Changes

- **`src/helpers/repeat.ts`**: Changed `i < rawNum` → `i < num` in the `for` loop (line 12)

### Testing

- All 46 existing unit tests pass ✅
- No behavioral change for valid numeric inputs
