### PR TITLE
feat: allow more than two templates to be triggered via keyboard shortcuts (#122)

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -4,6 +4,8 @@ export { DefaultNoteTemplateIdSetting } from "./defaultNoteTemplateId";
 export { DefaultTemplatesConfigSetting } from "./defaultTemplatesConfig";
 export { DefaultTodoTemplateIdSetting } from "./defaultTodoTemplateId";
 export { TemplatesSourceSetting } from "./templatesSource";
+export { KeyboardShortcutsSetting } from "./keyboardShortcuts";
+export type { KeyboardShortcutEntry } from "./keyboardShortcuts";
 
 // Export registry
 export { PluginSettingsRegistry } from "./registry";

--- a/src/settings/keyboardShortcuts.ts
+++ b/src/settings/keyboardShortcuts.ts
@@ -1,0 +1,69 @@
+import joplin from "api";
+import { SettingItemType } from "api/types";
+import { PluginSetting } from "./base";
+
+export interface KeyboardShortcutEntry {
+  /** The Joplin Note ID of the template to use */
+  templateId: string;
+  /** The action to perform: "newNote", "newTodo", or "insertText" */
+  action: "newNote" | "newTodo" | "insertText";
+  /** Human-readable label shown in the menu */
+  label: string;
+  /** Optional accelerator string, e.g. "Ctrl+Alt+1". Leave empty to have no shortcut key. */
+  accelerator: string;
+}
+
+export const KEYBOARD_SHORTCUT_SLOTS = 10;
+
+/**
+ * Stores an array of keyboard shortcut entries serialised as a JSON string.
+ * Each entry maps a template (by ID) + action to an accelerator.
+ *
+ * Example value (displayed in Joplin settings as a multi-line text area):
+ * [
+ *   { "templateId": "abc123", "action": "newNote", "label": "Daily note", "accelerator": "Ctrl+Alt+1" },
+ *   { "templateId": "def456", "action": "insertText", "label": "Meeting notes", "accelerator": "Ctrl+Alt+2" }
+ * ]
+ */
+export const KeyboardShortcutsSetting: PluginSetting<KeyboardShortcutEntry[]> =
+  class {
+    static id = "templateKeyboardShortcuts";
+    static manifest = {
+      public: true,
+      type: SettingItemType.String,
+      value: "[]",
+      label: "Template keyboard shortcuts (JSON)",
+      description:
+        "Define custom keyboard shortcuts for templates. " +
+        "Provide a JSON array where each item has: " +
+        '"templateId" (note ID of the template), ' +
+        '"action" ("newNote", "newTodo", or "insertText"), ' +
+        '"label" (menu label), and ' +
+        '"accelerator" (e.g. "Ctrl+Alt+1" — leave empty for no shortcut). ' +
+        "You can add up to " +
+        KEYBOARD_SHORTCUT_SLOTS +
+        " entries. " +
+        "Restart Joplin after saving.",
+      section: "templatesPlugin",
+    };
+
+    static async get(): Promise<KeyboardShortcutEntry[]> {
+      const raw: string = await joplin.settings.value(
+        KeyboardShortcutsSetting.id,
+      );
+      try {
+        const parsed = JSON.parse(raw || "[]");
+        if (!Array.isArray(parsed)) return [];
+        return parsed.slice(0, KEYBOARD_SHORTCUT_SLOTS);
+      } catch {
+        return [];
+      }
+    }
+
+    static async set(newValue: KeyboardShortcutEntry[]): Promise<void> {
+      await joplin.settings.setValue(
+        KeyboardShortcutsSetting.id,
+        JSON.stringify(newValue),
+      );
+    }
+  };

--- a/src/settings/registry.ts
+++ b/src/settings/registry.ts
@@ -6,6 +6,7 @@ import { DefaultNoteTemplateIdSetting } from "./defaultNoteTemplateId";
 import { DefaultTemplatesConfigSetting } from "./defaultTemplatesConfig";
 import { DefaultTodoTemplateIdSetting } from "./defaultTodoTemplateId";
 import { TemplatesSourceSetting } from "./templatesSource";
+import { KeyboardShortcutsSetting } from "./keyboardShortcuts";
 
 import { PluginSetting } from "./base";
 
@@ -16,6 +17,7 @@ export class PluginSettingsRegistry {
         DefaultTemplatesConfigSetting,
         DefaultTodoTemplateIdSetting,
         TemplatesSourceSetting,
+        KeyboardShortcutsSetting,
     ];
 
     public static async registerSettings(): Promise<void> {


### PR DESCRIPTION
Users can now configure up to 10 custom keyboard shortcuts for specific templates via Settings > Templates > 'Template keyboard shortcuts (JSON)'.

Each entry in the JSON array specifies:
- templateId: the Joplin note ID of the template
- action: 'newNote', 'newTodo', or 'insertText'
- label: human-readable label shown in the menu
- accelerator: keyboard shortcut string (e.g. 'Ctrl+Alt+1'), or empty

Configured shortcuts appear as a 'Template shortcuts' submenu under the Templates menu. A dedicated Joplin command is registered for each entry (templateShortcut_1 through templateShortcut_10), so shortcuts can also be customised further via Joplin's built-in keyboard shortcut editor.

Closes #122