### PR TITLE
fix: use parsed integer num instead of rawNum in repeat helper loop

### DIFF
--- a/src/helpers/repeat.ts
+++ b/src/helpers/repeat.ts
@@ -9,7 +9,7 @@ export const repeatHelper: HelperConstructorBlock = (ctx) => {
         }
 
         let ret = "";
-        for (let i = 0; i < rawNum; i++) {
+        for (let i = 0; i < num; i++) {
             ret += options.fn({ ...this, "repeat_index": i });
         }
         return ret;


### PR DESCRIPTION


Fixes #124

In [src/helpers/repeat.ts](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Joplin/plugin-templates/src/helpers/repeat.ts:0:0-0:0), the [repeat](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Joplin/plugin-templates/src/helpers/repeat.ts:2:0-16:2) helper was using `rawNum` (a raw string) instead of `num` (the parsed integer) in the [for](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Joplin/plugin-templates/src/index.ts:64:8-67:9) loop condition.

After fix :
<img width="1488" height="560" alt="image" src="https://github.com/user-attachments/assets/70032b24-7da7-4570-a788-ae31c65b61b0" />


 Problem

```typescript
// Bug: rawNum is a string
for (let i = 0; i < rawNum; i++) {