### PR TITLE
fix: respect geo-location settings when creating notes from templates

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,6 +3,7 @@ import { NewNote } from "./parser";
 import { getSelectedFolder } from "./utils/folders";
 import { applyTagToNote, getAnyTagWithTitle } from "./utils/tags";
 import { ApplyTagsWhileInsertingSetting } from "./settings";
+import { getGeoLocationForNote } from "./utils/geolocation";
 
 export enum TemplateAction {
     NewNote = "newNote",
@@ -25,10 +26,19 @@ const performInsertTextAction = async (template: NewNote) => {
 
 const performNewNoteAction = async (template: NewNote, isTodo: 0 | 1) => {
     const folderId = template.folder ? template.folder : await getSelectedFolder();
-    const notePayload = { body: template.body, parent_id: folderId, title: template.title, is_todo: isTodo };
+    const notePayload: Record<string, unknown> = { body: template.body, parent_id: folderId, title: template.title, is_todo: isTodo };
 
     if (isTodo && template.todo_due) {
         notePayload["todo_due"] = template.todo_due;
+    }
+
+    const geoLocation = await getGeoLocationForNote();
+    if (geoLocation) {
+        notePayload["latitude"] = geoLocation.latitude;
+        notePayload["longitude"] = geoLocation.longitude;
+        if (geoLocation.altitude !== undefined) {
+            notePayload["altitude"] = geoLocation.altitude;
+        }
     }
 
     const note = await joplin.data.post(["notes"], null, notePayload);

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,0 +1,62 @@
+import joplin from "api";
+
+export interface GeoLocation {
+    latitude: number;
+    longitude: number;
+    altitude?: number;
+}
+
+/**
+ * Checks whether the user has enabled "Save geo-location with notes" in Joplin settings.
+ */
+export const isGeoLocationEnabled = async (): Promise<boolean> => {
+    try {
+        const value = await joplin.settings.globalValue("note.saveGeolocation");
+        return value === true;
+    } catch {
+        // If the setting key is unavailable, default to false
+        return false;
+    }
+};
+
+/**
+ * Gets the current GPS coordinates using the browser's geolocation API.
+ * Joplin runs on Electron, so navigator.geolocation is available.
+ * Returns null if geolocation is unavailable or the user denies permission.
+ */
+export const getCurrentLocation = (): Promise<GeoLocation | null> => {
+    return new Promise((resolve) => {
+        if (typeof navigator === "undefined" || !navigator.geolocation) {
+            resolve(null);
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                resolve({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    altitude: position.coords.altitude ?? undefined,
+                });
+            },
+            () => {
+                // User denied or error — resolve with null gracefully
+                resolve(null);
+            },
+            {
+                timeout: 5000,
+                maximumAge: 60000,
+            }
+        );
+    });
+};
+
+/**
+ * Returns geo-location data to attach to a note, respecting the Joplin setting.
+ * Returns null if the setting is disabled or location cannot be determined.
+ */
+export const getGeoLocationForNote = async (): Promise<GeoLocation | null> => {
+    const enabled = await isGeoLocationEnabled();
+    if (!enabled) return null;
+    return await getCurrentLocation();
+};


### PR DESCRIPTION
Fixes #118

Notes created using templates did not include geo-location information (latitude, longitude, altitude), even when the "Save geo-location with notes" setting was enabled in Joplin preferences.


## Fix

Added a new utility [src/utils/geolocation.ts](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Joplin/plugin-templates/src/utils/geolocation.ts:0:0-0:0) that:
1. Reads Joplin's `note.saveGeolocation` global setting
2. Fetches current GPS coordinates via `navigator.geolocation`
3. Returns null gracefully if the setting is disabled or permission is denied

Updated [src/actions.ts](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Joplin/plugin-templates/src/actions.ts:0:0-0:0) to attach `latitude`, `longitude`, and `altitude` 
to the note payload when geo-location is enabled.

## Testing

- Enabled "Save geo-location with notes" in Joplin Preferences → Note
- Created a note from template via Tools → Templates → Create note from template
- Verified via Joplin REST API that the note has real GPS coordinates:

After Fix : 
<img width="964" height="192" alt="image" src="https://github.com/user-attachments/assets/917aac7c-408e-475d-8163-573c23acfb63" />




